### PR TITLE
correct Sec Output desc

### DIFF
--- a/lib/aio_system/MachineProcessor.cpp
+++ b/lib/aio_system/MachineProcessor.cpp
@@ -43,8 +43,8 @@ const uint8_t SLEEP_PINS[3] = {
 
 // In independent mode:
 // - Each INx directly controls OUTx
-// - HIGH on INx = OUTx sinks current (LED ON)
-// - LOW on INx = OUTx high impedance (LED OFF)
+// - HIGH on INx = OUTx sources current (LED ON, Output pushed HIGH)
+// - LOW on INx = OUTx sinks current (LED OFF, Output pulled LOW)
 
 // Static instance pointers
 MachineProcessor* MachineProcessor::instance = nullptr;


### PR DESCRIPTION
The DRV8243 outputs either sink or source current when the drv is enabled (not in sleep & not drvoff)